### PR TITLE
Support to keep comments.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ Options
 -------
 - let g:verilog_instance_skip_last_coma = {0/1}
     - When the variable is 1, last printed line will skip the coma. Default value is 0.
+- let g:verilog_instance_keep_comments = {0/1}
+    - When the variable is 1, comments will be kept (block comments /* */ not support!). Default value is 0.
+- let g:verilog_instance_keep_empty_lines = {0/1}
+    - When the variable is 1, empty lines in your code will be printed. Default value is 0.
 
 Other vim plugins for Verilog/SystemVerilog
 ---------------------------------------

--- a/doc/verilog_instance.txt
+++ b/doc/verilog_instance.txt
@@ -37,6 +37,16 @@ OPTIONS                                         *verilog-instance-options*
         When the variable is 1, last printed line will skip the coma.
         The default value is 0.
 
+                                                *g:verilog_instance_keep_comments*
+        let g:verilog_instance_keep_comments = {0/1}
+        When the variable is 1, comments will be kept (block comments /* */ not support!).
+        The default value is 0.
+
+                                                *g:verilog_instance_keep_empty_lines*
+        let g:verilog_instance_keep_empty_lines = {0/1}
+        When the variable is 1, empty lines in your code will be printed.
+        The default value is 0.
+
 ------------------------------------------------------------------------------
 KEY MAPPINGS                                    *verilog-instance-key-mappings*
 

--- a/plugin/verilog_instance.py
+++ b/plugin/verilog_instance.py
@@ -50,6 +50,9 @@ for line in sys.stdin:
     # get indentation length from 1st non empty line
     if indent_len == -1 and not(pattern_empty_line.match(line)):
         indent_len = len(re.match(r'^\s*', line).group(0))
+    # handle empty line
+    if pattern_empty_line.match(line) is not None:
+        contents.append('')
     # handle comments
     if wait_to_close_comment:
         if pattern_close_comment.search(line):

--- a/plugin/verilog_instance.py
+++ b/plugin/verilog_instance.py
@@ -8,8 +8,13 @@ import re
 import sys
 
 skip_last_coma = 0
+keep_comment = 1
+keep_empty_line = 1
 if len(sys.argv) > 1:
     skip_last_coma = int(sys.argv[1])
+
+if len(sys.argv) > 2:
+    keep_comment = int(sys.argv[2])
 
 keywords = []
 keywords.extend(["input", "output", "inout", "ref", "parameter", "localparam"])
@@ -19,7 +24,7 @@ keywords.extend(["const", "unsigned"])
 patterns = []
 patterns.append(re.compile(r'\[[^\[\]]*\]'))  # port size, array size
 patterns.append(re.compile(r'=.*'))           # assignment
-patterns.append(re.compile(r'//.*'))          # // comment
+patterns.append(re.compile(r'//.*') )
 patterns.append(re.compile(r'\w+\.\w+'))      # interfaces with modport
 for kw in keywords:                           # match keywords
     patterns.append(re.compile("\\b%s\\b" % kw))
@@ -32,7 +37,12 @@ pattern_punctuation = re.compile(r'[,;]')
 pattern_two_words_no_coma = re.compile(r'^\s*(\w+)\s+(\w+.*)')
 pattern_spaces = re.compile(r'\s+')
 
+pattern_inline_comment_kept = re.compile(r'.*\w+.*(//.*)')      # comment in port define
+pattern_comment_kept = re.compile(r'\s*(//.*)')               # one line comment
+
 ports = []
+ports_comments = {}   # save comment for every port
+contents = []          # save ports and single line comments
 wait_to_close_comment = 0
 indent_len = -1
 
@@ -53,6 +63,14 @@ for line in sys.stdin:
         else:
             wait_to_close_comment = 1
             continue
+    # handle port comment
+    port_comment = pattern_inline_comment_kept.match(line)
+    if port_comment is not None:
+        port_comment = port_comment.group(1)
+    # handle single line comment
+    line_comment = pattern_comment_kept.match(line)
+    if line_comment is not None:
+        line_comment = line_comment.group(1)
     # handle all other patterns
     for pattern in patterns:
         line = pattern.sub(' ', line)
@@ -63,16 +81,41 @@ for line in sys.stdin:
     # finally, get port names
     line = line.strip()
     if line != "":
-        ports.extend(line.split(' '))
+        port_names = line.split(' ')
+        ports.extend(port_names)
+        contents.extend(port_names)
+        for port in port_names:
+                ports_comments[port] = port_comment
+    else:
+        # add single line comment to port
+        if line_comment is not None:
+                contents.append(line_comment)
 
 ports_nb = len(ports)
 i = 0
 if ports_nb > 0:
     max_str_len = len(max(ports, key=len))
-    for port in ports:
+    indent_str = " " * indent_len
+    for content in contents:
+        if len(content) > 0:
+            if content[:2] == "//":
+                if keep_comment == 1:
+                    print(f'{indent_str}{content}')
+                continue
+        else:
+            # empty line
+            if keep_empty_line == 1:
+                print('')
+            continue
+        port = content
         skip_coma = skip_last_coma and i == (ports_nb - 1)
         space_str = " " * (max_str_len - len(port))
-        indent_str = " " * indent_len
-        print("%s.%s%s (%s%s)%s" % (
-            indent_str, port, space_str, port, space_str, (",", "")[skip_coma]))
+        output_line_port = "%s.%s%s (%s%s)%s" % (
+            indent_str, port, space_str, port, space_str, (",", "")[skip_coma])
+        if ports_comments.get(port) is not None and keep_comment == 1:
+            # add port comment
+            output_line = f"{output_line_port}  {ports_comments.get(port)}"
+        else:
+            output_line = output_line_port
+        print(output_line)
         i = i + 1

--- a/plugin/verilog_instance.vim
+++ b/plugin/verilog_instance.vim
@@ -12,6 +12,14 @@ if !get(g:, 'verilog_instance_skip_last_coma')
   let g:verilog_instance_skip_last_coma = 0
 endif
 
+if !get(g:, 'verilog_instance_keep_comments')
+  let g:verilog_instance_keep_comments = 0
+endif
+
+if !get(g:, 'verilog_instance_keep_empty_lines')
+  let g:verilog_instance_keep_empty_lines = 0
+endif
+
 function! s:VerilogInstance(type,...) abort
   if a:0
     let [lnum1, lnum2] = [a:type, a:1]
@@ -20,7 +28,7 @@ function! s:VerilogInstance(type,...) abort
   endif
   let cmd = lnum1 . "norm! =="
   execute cmd
-  let cmd = lnum1 . "," . lnum2 . "!" . " " . s:plugin_dir_path . "/verilog_instance.py " . g:verilog_instance_skip_last_coma
+  let cmd = lnum1 . "," . lnum2 . "!" . " " . s:plugin_dir_path . "/verilog_instance.py " . g:verilog_instance_skip_last_coma . g:verilog_instance_keep_comments . g:verilog_instance_keep_empty_lines
   execute cmd
 endfunction
 

--- a/test.sv
+++ b/test.sv
@@ -1,13 +1,15 @@
 module sub_block(
-  input                         clk,
+  input                         clk,   // 50 MHz clk
   input /* foo */               rstn,
   /* interface
   * network_if.IN   i0, i1,
   * network_if.OUT  o0, o1
   */
-  fifo_if_.IN                   i0, i1,
+  fifo_if_.IN                   i0, i1,  // fifo in
   fifo_if_.OUT                  o0, o1,
+
   input custom_t                data_in,
+  // output
   output reg[31:0] /*comment*/  reg32_out,
   output custom_t               data_out
 );


### PR DESCRIPTION
Hi,

I make some update of this plugin to **keep comments** and **empty lines** which are helpful in my daily work.

And this feature are require in #3 .

![Untitled](https://user-images.githubusercontent.com/22850287/224541593-c7c36098-ea1c-43dc-b9c6-5a1ed1b6cedd.gif)

For the compatibility, I assign two configure vars for plugin and set the features off as default.
```
let g:verilog_instance_keep_comments = {0/1}
let g:verilog_instance_keep_empty_lines = {0/1}
```
